### PR TITLE
Feature/dvop 2491 create new ci kafka client container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,29 @@
-FROM amazonlinux:latest
+FROM alpine:latest as builder
 
-ARG CONFLUENT_KAFKA_VERSION=2.11
-ARG JDK_VERSION=1.8.0
+ARG KAFKA_VERSION=0.11.0.0
+ARG SCALA_VERSION=2.11
+
+RUN apk update && apk add --no-cache wget tar gzip
+
+RUN wget https://archive.apache.org/dist/kafka/0.11.0.0/kafka_${SCALA_VERSION}-0.11.0.0.tgz && \
+    tar -xzf kafka_${SCALA_VERSION}-0.11.0.0.tgz && \
+    rm kafka_${SCALA_VERSION}-0.11.0.0.tgz
+
+FROM amazonlinux:2023
+
+ARG KAFKA_HOME=/opt/kafka
+ARG KAFKA_VERSION=0.11.0.0
+ARG SCALA_VERSION=2.11
 ARG YUM_REPOSITORY=yum-repository.platform.aws.chdev.org
 
-COPY resources/confluent.repo /etc/yum.repos.d/confluent.repo
+ENV PATH "${PATH}:${KAFKA_HOME}/bin"
+
+COPY --from=builder /kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}
+
+RUN ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} ${KAFKA_HOME}
 
 RUN yum update -y && \
-    yum install -y java-${JDK_VERSION}-openjdk.x86_64 \
-    confluent-kafka-${CONFLUENT_KAFKA_VERSION} && \
+    yum install -y java-21-amazon-corretto-headless &&  \
     yum clean all
 
 RUN rpm --import http://${YUM_REPOSITORY}/RPM-GPG-KEY-platform-noarch && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,25 +5,25 @@ ARG SCALA_VERSION=2.11
 
 RUN apk update && apk add --no-cache wget tar gzip
 
-RUN wget https://archive.apache.org/dist/kafka/0.11.0.0/kafka_${SCALA_VERSION}-0.11.0.0.tgz && \
-    tar -xzf kafka_${SCALA_VERSION}-0.11.0.0.tgz && \
-    rm kafka_${SCALA_VERSION}-0.11.0.0.tgz
+RUN wget https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz && \
+    tar -xzf kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz && \
+    rm kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
 
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 ARG KAFKA_HOME=/opt/kafka
 ARG KAFKA_VERSION=0.11.0.0
 ARG SCALA_VERSION=2.11
 ARG YUM_REPOSITORY=yum-repository.platform.aws.chdev.org
 
-ENV PATH "${PATH}:${KAFKA_HOME}/bin"
+ENV PATH="${PATH}:${KAFKA_HOME}/bin"
 
 COPY --from=builder /kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}
 
 RUN ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} ${KAFKA_HOME}
 
 RUN yum update -y && \
-    yum install -y java-21-amazon-corretto-headless &&  \
+    yum install -y java-17-amazon-corretto-headless &&  \
     yum clean all
 
 RUN rpm --import http://${YUM_REPOSITORY}/RPM-GPG-KEY-platform-noarch && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM amazonlinux:latest
+
+ARG CONFLUENT_KAFKA_VERSION=2.11
+ARG JDK_VERSION=1.8.0
+ARG YUM_REPOSITORY=yum-repository.platform.aws.chdev.org
+
+COPY resources/confluent.repo /etc/yum.repos.d/confluent.repo
+
+RUN yum update -y && \
+    yum install -y java-${JDK_VERSION}-openjdk.x86_64 \
+    confluent-kafka-${CONFLUENT_KAFKA_VERSION} && \
+    yum clean all
+
+RUN rpm --import http://${YUM_REPOSITORY}/RPM-GPG-KEY-platform-noarch && \
+    yum install -y yum-utils && \
+    yum-config-manager --add-repo http://${YUM_REPOSITORY}/platform-noarch.repo && \
+    yum install -y platform-tools-common && \
+    yum clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN wget https://archive.apache.org/dist/kafka/0.11.0.0/kafka_${SCALA_VERSION}-0
     tar -xzf kafka_${SCALA_VERSION}-0.11.0.0.tgz && \
     rm kafka_${SCALA_VERSION}-0.11.0.0.tgz
 
-FROM amazonlinux:2023
+FROM amazonlinux:latest
 
 ARG KAFKA_HOME=/opt/kafka
 ARG KAFKA_VERSION=0.11.0.0

--- a/resources/confluent.repo
+++ b/resources/confluent.repo
@@ -1,0 +1,6 @@
+[confluent-3.0]
+name=Confluent repository for 3.0.x packages
+baseurl=http://packages.confluent.io/rpm/3.0
+gpgcheck=1
+gpgkey=http://packages.confluent.io/rpm/3.0/archive.key
+enabled=1

--- a/resources/confluent.repo
+++ b/resources/confluent.repo
@@ -1,6 +1,0 @@
-[confluent-3.0]
-name=Confluent repository for 3.0.x packages
-baseurl=http://packages.confluent.io/rpm/3.0
-gpgcheck=1
-gpgkey=http://packages.confluent.io/rpm/3.0/archive.key
-enabled=1


### PR DESCRIPTION
-updated ci-kafka-client to have a working version 11 docker image
-built and tested locally and functionality retained
-related to Jira ticketrelated to jira ticket dvop 2491